### PR TITLE
feat: UI polish — scroll-reveal, hover transitions, consistency fixes

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -13,3 +13,16 @@
         scrollbar-width: none;  /* Firefox */
   }
 }
+
+/* Scroll reveal */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  will-change: transform, opacity;
+}
+
+.reveal-visible {
+  opacity: 1 !important;
+  transform: translateY(0) !important;
+}

--- a/src/components/Blogs.vue
+++ b/src/components/Blogs.vue
@@ -9,7 +9,7 @@
                 :href="blog.link"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="flex flex-col px-5 py-3 bg-[#202020]/[.3] border-[#504945] border-[0.5px] rounded-lg text-sm"
+                class="flex flex-col px-5 py-3 bg-[#202020]/[.3] border-[#504945] border-[0.5px] rounded-lg text-sm hover:-translate-y-1 hover:border-one-dark-gray transition-all duration-200"
             >
                 <!-- Blog Image (always on top) -->
                 <div
@@ -18,7 +18,7 @@
                 >
                     <img
                         :data-src="getBlogImage(blog) || profileImage"
-                        class="rounded w-full lg:h-32 h-full object-contain lg:object-cover"
+                        class="rounded w-full h-32 object-cover"
                         :alt="blog.title"
                     />
                 </div>

--- a/src/components/Experience.vue
+++ b/src/components/Experience.vue
@@ -12,7 +12,7 @@
                 <!-- Odd Index - Timeline Item Right -->
                 <div v-if="index % 2 === 0" class="mb-8 flex items-center justify-start md:mb-14">
                     <div class="w-full md:w-1/2 text-left pl-6 pr-6 md:text-right">
-                        <h3 class="font-bold text-2xl font-sans">
+                        <h3 class="font-bold text-xl font-sans">
                             {{ experience.title }}
                         </h3>
                         <p class="text-xs text-one-dark-foreground font-sans md:text-sm">
@@ -20,14 +20,14 @@
                                 rel="noopener noreferrer">{{ experience.company }}</a>,
                             {{ experience.period }}
                         </p>
-                        <p class="mt-2 text-one-dark-foreground text-xs hidden md:block">
+                        <p class="mt-2 text-one-dark-foreground text-xs">
                             {{ experience.description }}
                         </p>
                     </div>
                     <div :class="index !== 0
                         ? 'bg-one-dark-red'
                         : 'bg-one-dark-green'
-                        " class="w-8 h-8 rounded-full border-4 border-one-dark-bg z-0 hidden md:block md:-ml-4"></div>
+                        " class="w-8 h-8 rounded-full border-4 border-one-dark-bg z-0 hidden md:block md:-ml-4 hover:ring-2 hover:ring-one-dark-green transition-all duration-200 cursor-default"></div>
                 </div>
 
                 <!-- Even Index - Timeline Item Left -->
@@ -35,7 +35,7 @@
                     <div :class="index !== 0
                         ? 'bg-one-dark-red'
                         : 'bg-one-dark-green'
-                        " class="w-8 h-8 rounded-full border-4 border-one-dark-bg z-0 hidden md:block md:-mr-4"></div>
+                        " class="w-8 h-8 rounded-full border-4 border-one-dark-bg z-0 hidden md:block md:-mr-4 hover:ring-2 hover:ring-one-dark-green transition-all duration-200 cursor-default"></div>
                     <div class="w-full md:w-1/2 text-left pl-6 pr-6">
                         <h3 class="font-bold text-xl font-sans">
                             {{ experience.title }}
@@ -44,7 +44,7 @@
                             <a class="text-one-dark-blue font-bold" :href="experience.companyWebsite"
                                 rel="noopener noreferrer">{{ experience.company }}</a>, {{ experience.period }}
                         </p>
-                        <p class="mt-2 text-one-dark-foreground text-xs hidden md:block">
+                        <p class="mt-2 text-one-dark-foreground text-xs">
                             {{ experience.description }}
                         </p>
                     </div>

--- a/src/components/Experience.vue
+++ b/src/components/Experience.vue
@@ -55,8 +55,6 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
-
 const experiences = [
     {
         title: "Backend Web Developer Intern",

--- a/src/components/Github.vue
+++ b/src/components/Github.vue
@@ -10,7 +10,7 @@
             <div v-if="!repos.length">Github repos could not be retrieved.</div>
             <a v-bind:key="repo.html_url" v-for="repo in repos" :href="repo.html_url" target="_blank"
                 rel="noopener noreferrer"
-                class="flex flex-col justify-between px-5 py-3 bg-[#202020]/[.3] border-[#504945] border-[0.5px] rounded-lg text-sm">
+                class="flex flex-col justify-between px-5 py-3 bg-[#202020]/[.3] border-[#504945] border-[0.5px] rounded-lg text-sm hover:-translate-y-1 hover:border-one-dark-gray transition-all duration-200">
                 <div>
                     <div v-lazy-container="{ selector: 'img' }"
                         class="flex items-center gap-2 text-one-dark-foreground">

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -83,7 +83,7 @@
             </div>
             <div class="flex gap-4 mt-8 text-xl md:text-2xl md:gap-5 md:mx-0">
                 <a v-for="(link, key) in socials" :key="key" :href="link" :alt="key" target="_blank"
-                    rel="noopener noreferrer" class="relative group">
+                    rel="noopener noreferrer" class="relative group hover:scale-125 transition-transform duration-150">
                     <!-- Font Awesome Icon -->
                     <font-awesome-icon :icon="[
                         'fab',

--- a/src/components/Project.vue
+++ b/src/components/Project.vue
@@ -16,7 +16,7 @@
                         <h3 class="text-xl font-bold font-sans md:text-2xl">
                             {{ slide.title }}
                         </h3>
-                        <p class="text-xs text-one-dark-foreground md:text-sm">
+                        <p class="text-xs text-one-dark-white md:text-sm">
                             {{ slide.desc }}
                         </p>
                     </div>

--- a/src/components/Project.vue
+++ b/src/components/Project.vue
@@ -25,8 +25,9 @@
 
             <!-- Prev Arrow -->
             <button
+                type="button"
                 @click.stop="prevSlide"
-                class="absolute left-2 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center min-w-[44px] min-h-[44px] w-10 h-10 rounded-full bg-one-dark-bg/70 hover:bg-one-dark-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-one-dark-green"
+                class="absolute left-2 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full bg-one-dark-bg/70 hover:bg-one-dark-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-one-dark-green"
                 aria-label="Previous slide"
             >
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-one-dark-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -36,8 +37,9 @@
 
             <!-- Next Arrow -->
             <button
+                type="button"
                 @click.stop="nextSlide"
-                class="absolute right-2 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center min-w-[44px] min-h-[44px] w-10 h-10 rounded-full bg-one-dark-bg/70 hover:bg-one-dark-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-one-dark-green"
+                class="absolute right-2 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full bg-one-dark-bg/70 hover:bg-one-dark-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-one-dark-green"
                 aria-label="Next slide"
             >
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-one-dark-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/src/components/Project.vue
+++ b/src/components/Project.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <h2 class="mb-3 font-black text-2xl">~/projects/</h2>
-        <div class="relative w-full" ref="carouselRef">
+        <div class="relative w-full" ref="carouselRef" @keydown.left.prevent="prevSlide" @keydown.right.prevent="nextSlide" tabindex="0">
             <!-- Carousel Items -->
             <div class="w-full h-full overflow-hidden relative border-one-dark-white[0.5px]" @touchstart="onTouchStart"
                 @touchmove="onTouchMove" @touchend="onTouchEnd">
@@ -16,12 +16,34 @@
                         <h3 class="text-xl font-bold font-sans md:text-2xl">
                             {{ slide.title }}
                         </h3>
-                        <p class="text-xs text-one-dark-white md:text-sm">
+                        <p class="text-xs text-one-dark-foreground md:text-sm">
                             {{ slide.desc }}
                         </p>
                     </div>
                 </div>
             </div>
+
+            <!-- Prev Arrow -->
+            <button
+                @click.stop="prevSlide"
+                class="absolute left-2 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center min-w-[44px] min-h-[44px] w-10 h-10 rounded-full bg-one-dark-bg/70 hover:bg-one-dark-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-one-dark-green"
+                aria-label="Previous slide"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-one-dark-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                </svg>
+            </button>
+
+            <!-- Next Arrow -->
+            <button
+                @click.stop="nextSlide"
+                class="absolute right-2 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center min-w-[44px] min-h-[44px] w-10 h-10 rounded-full bg-one-dark-bg/70 hover:bg-one-dark-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-one-dark-green"
+                aria-label="Next slide"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-one-dark-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+            </button>
 
             <!-- Indicators -->
             <div class="indicators flex justify-center space-x-2 mt-4">

--- a/src/components/Tools.vue
+++ b/src/components/Tools.vue
@@ -12,12 +12,21 @@
                     <div
                         class="grid grid-cols-4 md:grid-cols-5 lg:grid-cols-7 gap-3"
                     >
-                        <i
+                        <div
                             v-for="(icon, index) in stackIcons"
                             :key="index"
-                            :class="icon.class"
-                            style="font-size: 3rem"
-                        ></i>
+                            class="relative group flex items-center justify-center"
+                        >
+                            <i
+                                :class="icon.class"
+                                style="font-size: 3rem"
+                            ></i>
+                            <span
+                                class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs font-medium text-one-dark-bg bg-one-dark-foreground rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap shadow-lg z-10"
+                            >
+                                {{ icon.name }}
+                            </span>
+                        </div>
                     </div>
                 </div>
                 <div class="mb-2">
@@ -25,12 +34,21 @@
                     <div
                         class="grid grid-cols-4 md:grid-cols-5 lg:grid-cols-7 gap-3"
                     >
-                        <i
+                        <div
                             v-for="(icon, index) in serviceIcons"
                             :key="index"
-                            :class="icon.class"
-                            style="font-size: 3rem"
-                        ></i>
+                            class="relative group flex items-center justify-center"
+                        >
+                            <i
+                                :class="icon.class"
+                                style="font-size: 3rem"
+                            ></i>
+                            <span
+                                class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs font-medium text-one-dark-bg bg-one-dark-foreground rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap shadow-lg z-10"
+                            >
+                                {{ icon.name }}
+                            </span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -39,35 +57,35 @@
 </template>
 <script setup>
 const stackIcons = [
-    { class: "devicon-android-plain colored" },
-    { class: "devicon-bootstrap-plain colored" },
-    { class: "devicon-css3-plain-wordmark colored" },
-    { class: "devicon-git-plain colored" },
-    { class: "devicon-go-plain colored" },
-    { class: "devicon-html5-plain-wordmark colored" },
-    { class: "devicon-java-plain-wordmark colored" },
-    { class: "devicon-javascript-plain colored" },
-    { class: "devicon-jquery-plain-wordmark colored" },
-    { class: "devicon-kotlin-plain colored" },
-    { class: "devicon-mysql-plain-wordmark colored" },
-    { class: "devicon-nodejs-plain-wordmark colored" },
-    { class: "devicon-postgresql-plain colored" },
-    { class: "devicon-python-plain colored" },
-    { class: "devicon-react-original colored" },
-    { class: "devicon-ruby-plain-wordmark colored" },
-    { class: "devicon-sqlite-plain colored" },
-    { class: "devicon-typescript-plain colored" },
-    { class: "devicon-vuejs-plain colored" },
-    { class: "devicon-laravel-plain colored" },
-    { class: "devicon-php-plain colored" },
+    { class: "devicon-android-plain colored", name: "Android" },
+    { class: "devicon-bootstrap-plain colored", name: "Bootstrap" },
+    { class: "devicon-css3-plain-wordmark colored", name: "CSS3" },
+    { class: "devicon-git-plain colored", name: "Git" },
+    { class: "devicon-go-plain colored", name: "Go" },
+    { class: "devicon-html5-plain-wordmark colored", name: "HTML5" },
+    { class: "devicon-java-plain-wordmark colored", name: "Java" },
+    { class: "devicon-javascript-plain colored", name: "JavaScript" },
+    { class: "devicon-jquery-plain-wordmark colored", name: "jQuery" },
+    { class: "devicon-kotlin-plain colored", name: "Kotlin" },
+    { class: "devicon-mysql-plain-wordmark colored", name: "MySQL" },
+    { class: "devicon-nodejs-plain-wordmark colored", name: "Node.js" },
+    { class: "devicon-postgresql-plain colored", name: "PostgreSQL" },
+    { class: "devicon-python-plain colored", name: "Python" },
+    { class: "devicon-react-original colored", name: "React" },
+    { class: "devicon-ruby-plain-wordmark colored", name: "Ruby" },
+    { class: "devicon-sqlite-plain colored", name: "SQLite" },
+    { class: "devicon-typescript-plain colored", name: "TypeScript" },
+    { class: "devicon-vuejs-plain colored", name: "Vue.js" },
+    { class: "devicon-laravel-plain colored", name: "Laravel" },
+    { class: "devicon-php-plain colored", name: "PHP" },
 ];
 const serviceIcons = [
-    { class: "devicon-github-original-wordmark" },
-    { class: "devicon-googlecloud-plain colored" },
-    { class: "devicon-firebase-plain colored" },
-    { class: "devicon-bitbucket-plain colored" },
-    { class: "devicon-cloudflare-plain colored" },
-    { class: "devicon-amazonwebservices-plain colored" },
-    { class: "devicon-appwrite-plain colored" },
+    { class: "devicon-github-original-wordmark", name: "GitHub" },
+    { class: "devicon-googlecloud-plain colored", name: "Google Cloud" },
+    { class: "devicon-firebase-plain colored", name: "Firebase" },
+    { class: "devicon-bitbucket-plain colored", name: "Bitbucket" },
+    { class: "devicon-cloudflare-plain colored", name: "Cloudflare" },
+    { class: "devicon-amazonwebservices-plain colored", name: "AWS" },
+    { class: "devicon-appwrite-plain colored", name: "Appwrite" },
 ];
 </script>

--- a/src/composables/useScrollReveal.js
+++ b/src/composables/useScrollReveal.js
@@ -1,0 +1,42 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export function useScrollReveal(refs) {
+  let observer = null
+
+  onMounted(() => {
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches
+
+    if (prefersReducedMotion) {
+      // Skip animation entirely — mark all visible immediately
+      refs.forEach((ref) => {
+        if (ref.value) ref.value.classList.add('reveal-visible')
+      })
+      return
+    }
+
+    observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('reveal-visible')
+            observer.unobserve(entry.target) // animate once
+          }
+        })
+      },
+      { threshold: 0.1 }
+    )
+
+    refs.forEach((ref) => {
+      if (ref.value) {
+        ref.value.classList.add('reveal')
+        observer.observe(ref.value)
+      }
+    })
+  })
+
+  onUnmounted(() => {
+    if (observer) observer.disconnect()
+  })
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -16,40 +16,40 @@
         <div class="z-0 absolute -mt-5 ml-5 left-0 text-[5rem] opacity-15 select-none">
             🚀
         </div>
-        <div class="relative mb-10">
+        <div ref="headerRef" class="relative mb-12">
             <Header />
         </div>
-        <div class="mb-10">
+        <div ref="toolsRef" class="mb-12">
             <Tools />
         </div>
         <div
-            class="z-0 right-0 top-[47rem] md:bottom-[80rem] absolute mb-10 ml-7 text-[7rem] opacity-10 select-none lg:block hidden">
+            class="z-0 right-0 top-[47rem] md:bottom-[80rem] absolute mb-12 ml-7 text-[7rem] opacity-10 select-none lg:block hidden">
             👨‍💻
         </div>
-        <div class="mb-10">
+        <div ref="projectRef" class="mb-12">
             <Project />
         </div>
         <div
-            class="z-0 right-0 top-[114rem] md:bottom-[80rem] absolute mb-10 mr-7 text-[7rem] opacity-15 select-none lg:block hidden">
+            class="z-0 right-0 top-[114rem] md:bottom-[80rem] absolute mb-12 mr-7 text-[7rem] opacity-15 select-none lg:block hidden">
             💼
         </div>
-        <div class="mb-10">
+        <div ref="experienceRef" class="mb-12">
             <Experience />
         </div>
         <div
-            class="z-0 left-0 top-[65rem] md:bottom-[80rem] absolute mb-10 ml-7 text-[9rem] opacity-5 select-none lg:block hidden">
+            class="z-0 left-0 top-[65rem] md:bottom-[80rem] absolute mb-12 ml-7 text-[9rem] opacity-5 select-none lg:block hidden">
             ⚙️
         </div>
-        <div class="relative mb-10">
+        <div ref="blogsRef" class="relative mb-12">
             <Blogs />
         </div>
         <div class="z-0 bottom-[46rem] left-0 absolute mb-5 ml-3 text-[9rem] opacity-10 select-none lg:block hidden">
             📕
         </div>
-        <div class="relative mb-16">
+        <div ref="githubRef" class="relative mb-12">
             <Github />
         </div>
-        <div class="relative mb-16">
+        <div ref="socialRef" class="relative mb-12">
             <SocialMedia />
         </div>
         <div class="z-0 bottom-14 right-0 absolute mb-3 mr-5 text-[7rem] opacity-15 select-none">
@@ -59,6 +59,7 @@
     </div>
 </template>
 <script setup>
+import { ref } from "vue";
 import Header from "../components/Header.vue";
 import Tools from "../components/Tools.vue";
 import Github from "../components/Github.vue";
@@ -67,4 +68,15 @@ import Blogs from "../components/Blogs.vue";
 import Project from "../components/Project.vue";
 import Experience from "../components/Experience.vue";
 import SocialMedia from "../components/SocialMedia.vue";
+import { useScrollReveal } from "../composables/useScrollReveal.js";
+
+const headerRef = ref(null);
+const toolsRef = ref(null);
+const projectRef = ref(null);
+const experienceRef = ref(null);
+const blogsRef = ref(null);
+const githubRef = ref(null);
+const socialRef = ref(null);
+
+useScrollReveal([headerRef, toolsRef, projectRef, experienceRef, blogsRef, githubRef, socialRef]);
 </script>


### PR DESCRIPTION
## Summary
- Add scroll-reveal entrance animations to all sections (fade up on scroll, respects `prefers-reduced-motion`)
- Add hover lift transitions to blog cards and GitHub repo cards; scale effect on header social icons; hover ring on experience timeline dots
- Add prev/next arrow buttons (44px tap targets) + keyboard navigation to project carousel
- Fix visual consistency: equalize experience timeline font sizes, show descriptions on mobile, fix blog image `object-cover`, add name tooltips to all 28 tech stack/service icons
- Normalize section spacing to `mb-12` throughout

## Test Plan
- [ ] Scroll down the page — each section should fade up into view on entry
- [ ] Hover over blog cards and GitHub repo cards — subtle lift effect
- [ ] Hover over header social icons — scale up with tooltip
- [ ] Click carousel prev/next arrows; focus carousel and use ← → keyboard arrows
- [ ] Check on mobile (375px) — descriptions visible in Experience, tap targets work on carousel
- [ ] Enable `prefers-reduced-motion` in OS — animations should be skipped, all content immediately visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)